### PR TITLE
Update artifacts.json with new resourcesTemplate URL

### DIFF
--- a/artifacts.json
+++ b/artifacts.json
@@ -1,3 +1,3 @@
 {
-  "resourcesTemplate": "https://4rlystorage.blob.core.windows.net/task-artifacts/task2/exported-template.json?sv=2025-07-05&se=2026-05-07T13%3A59%3A19Z&sr=b&sp=r&sig=VZfy64EE6rOO0ncYy9QsVM8wpwceDfzld5QwTTRKNc0%3D"
+    "resourcesTemplate": "https://4rlystorage.blob.core.windows.net/task-artifacts/task2/exported-template.json"
 }

--- a/artifacts.json
+++ b/artifacts.json
@@ -1,3 +1,3 @@
 {
-  "resourcesTemplate": ""
+  "resourcesTemplate": "https://4rlystorage.blob.core.windows.net/task-artifacts/task2/exported-template.json?sv=2025-07-05&se=2026-05-07T13%3A59%3A19Z&sr=b&sp=r&sig=VZfy64EE6rOO0ncYy9QsVM8wpwceDfzld5QwTTRKNc0%3D"
 }


### PR DESCRIPTION
I could not complete the VM deployment in UK South because my Azure subscription does not allow VM creation in that region. Azure Portal shows the error: "Your subscription doesn't support virtual machine creation in UK South.
Choose a different location."

Because of that, I deployed the closest available fallback configuration in UK West, attached a public IP separately, configured NSG rules for ports 22 and 8080, and deployed the application successfully.

The app is reachable at:
http://mate-azure-task-vitaliy.ukwest.cloudapp.azure.com:8080/api/

Local validation fails only on the strict region check in validate-artifacts.ps1, which expects UK South.
https://snipboard.io/2o3fU6.jpg
